### PR TITLE
fix multi-mapped variable with macro pulse number attached (cf. #9960)

### DIFF
--- a/include/DoocsProcessArray.h
+++ b/include/DoocsProcessArray.h
@@ -104,7 +104,10 @@ namespace ChimeraTK {
       // before calling this function because calling this function through a function pointer is
       // comparatively expensive.
       // Only check the consistency group if there is a macro pulse number associated.
-      if(_macroPulseNumberSource && !_consistencyGroup.update(transferElementId)) {
+      // Do not check if update is coming from another DOOCS property mapped to the same variable (ID invalid), since
+      // the check would never pass. Such variables cannot use exact data matching anyway, since the update is triggered
+      // from the DOOCS write to the other property.
+      if(transferElementId.isValid() && _macroPulseNumberSource && !_consistencyGroup.update(transferElementId)) {
         // data is not consistent (yet). Don't update the Doocs buffer.
         // check if this will now throw away data and generate a warning
         if(transferElementId == _processArray->getId()) {

--- a/include/DoocsProcessScalar.h
+++ b/include/DoocsProcessScalar.h
@@ -25,7 +25,10 @@ namespace ChimeraTK {
       // before calling this function because calling this function through a function pointer is
       // comparatively expensive.
       // Only check the consistency group if there is a macro pulse number associated.
-      if(_macroPulseNumberSource && !_consistencyGroup.update(transferElementId)) {
+      // Do not check if update is coming from another DOOCS property mapped to the same variable (ID invalid), since
+      // the check would never pass. Such variables cannot use exact data matching anyway, since the update is triggered
+      // from the DOOCS write to the other property.
+      if(transferElementId.isValid() && _macroPulseNumberSource && !_consistencyGroup.update(transferElementId)) {
         // data is not consistent (yet). Don't update the Doocs buffer.
         // check if this will now throw away data and generate a warning
         if(transferElementId == _processScalar->getId()) {

--- a/src/DoocsIfff.cc
+++ b/src/DoocsIfff.cc
@@ -58,8 +58,11 @@ namespace ChimeraTK {
     registerVariable(OneDRegisterAccessor<float>(_f3Value));
   }
 
-  void DoocsIfff::updateDoocsBuffer(const TransferElementID& elementId) {
-    if(!_consistencyGroup.update(elementId)) {
+  void DoocsIfff::updateDoocsBuffer(const TransferElementID& transferElementId) {
+    // Do not check if update is coming from another DOOCS property mapped to the same variable (ID invalid), since
+    // the check would never pass. Such variables cannot use exact data matching anyway, since the update is triggered
+    // from the DOOCS write to the other property.
+    if(transferElementId.isValid() && !_consistencyGroup.update(transferElementId)) {
       return;
     }
 

--- a/src/DoocsSpectrum.cc
+++ b/src/DoocsSpectrum.cc
@@ -132,7 +132,10 @@ namespace ChimeraTK {
     // There are only the processArray and the macro pulse number in the consistency
     // group. The limits are coming asynchronously and not for every macro pulse,
     // so we just take test latest we have.
-    if(_macroPulseNumberSource && !_consistencyGroup.update(transferElementId)) {
+    // Do not check if update is coming from another DOOCS property mapped to the same variable (ID invalid), since
+    // the check would never pass. Such variables cannot use exact data matching anyway, since the update is triggered
+    // from the DOOCS write to the other property.
+    if(transferElementId.isValid() && _macroPulseNumberSource && !_consistencyGroup.update(transferElementId)) {
       // data is not consistent (yet). Don't update the Doocs buffer.
       // check if this will now throw away data and generate a warning
       if(transferElementId == _processArray->getId()) {


### PR DESCRIPTION
If a macro pulse number is attached to a property which is mapped to a
variable mapped to also other properties, the update from the other,
writeable property was not getting through due to the consistency check.
This check is now effectively disabled in that case, which is ok, since
the update is anyway uncorrelated to the macro pulse number (since
coming from e.g. the operator).