### PR TITLE
fix crash if property array length mismatch

### DIFF
--- a/include/DoocsProcessArray.h
+++ b/include/DoocsProcessArray.h
@@ -236,10 +236,25 @@ namespace ChimeraTK {
       // always get a fresh reference
       auto& processVector = _processArray->accessChannel(0);
       size_t arraySize = processVector.size();
+      if(this->length() != arraySize) {
+        std::cout << "Warning: Array length mismatch in property " << this->getEqFct()->name() << "/"
+                  << this->basename() << ": Property has length " << this->length() << " but " << arraySize
+                  << " expected." << std::endl;
+        arraySize = std::min(arraySize, size_t(this->length()));
+      }
       for(size_t i = 0; i < arraySize; ++i) {
         processVector[i] = this->value(i);
       }
       _processArray->write();
+
+      // Correct property length in case of a mismatch.
+      if(this->length() != processVector.size()) {
+        this->set_length(processVector.size());
+        // restore value from ProcessArray, as it may have been destroyed in set_length().
+        for(size_t i = 0; i < arraySize; ++i) {
+          this->set_value(processVector[i], i);
+        }
+      }
 
       // make sure other properties using these PVs see the update
       if(getLocks) this->get_eqfct()->unlock();


### PR DESCRIPTION
This can happen e.g. if the ProcessArray length in the application has
changed but the old value is still in the DOOCS config file. If the new
length is bigger than the old one, the server crashed because it
attempted to read too many value from the property in auto_init.

This fix should also cover the case when a wrong length is set trough an
RPC call.