### PR TITLE
fix: Add new server variables from CSA

### DIFF
--- a/tests/src/serverTestCallOptimiseUnmappedVariables.cpp
+++ b/tests/src/serverTestCallOptimiseUnmappedVariables.cpp
@@ -25,8 +25,8 @@ using namespace ChimeraTK;
 DOOCS_ADAPTER_DEFAULT_FIXTURE
 
 BOOST_AUTO_TEST_CASE(testListOfUnmappedVariables) {
-  std::list<std::string> refAppModuleList = {
-      "CHAR", "UCHAR", "SHORT", "USHORT", "INT", "UINT", "LONG", "ULONG", "FLOAT", "DOUBLE", "STRING"};
+  std::list<std::string> refAppModuleList = {"CHAR", "UCHAR", "SHORT", "USHORT", "INT", "UINT", "LONG", "ULONG",
+      "FLOAT", "DOUBLE", "STRING", "BOOLEAN", "VOID"};
   std::list<std::string> refAppVarPerModuleList = {"TO_DEVICE_SCALAR", "FROM_DEVICE_SCALAR", "TO_DEVICE_ARRAY",
       "FROM_DEVICE_ARRAY", "DATA_TYPE_CONSTANT", "CONSTANT_ARRAY"};
   std::set<std::string> mappedVars = {"/DOUBLE/TO_DEVICE_ARRAY", "/FLOAT/TO_DEVICE_SCALAR", "/FLOAT/TO_DEVICE_SCALAR",
@@ -35,6 +35,10 @@ BOOST_AUTO_TEST_CASE(testListOfUnmappedVariables) {
   std::cout << "=== Expected list: " << std::endl;
   for(auto& m : refAppModuleList) {
     for(auto& v : refAppVarPerModuleList) {
+      // VOID does not have constants or arrays, so skip those in the check
+      if(m == "VOID" && ((v.find("CONSTANT") != std::string::npos) || (v.find("ARRAY") != std::string::npos))) {
+        continue;
+      }
       std::string name = "/" + m + "/" + v;
       if(mappedVars.find(name) == mappedVars.end()) {
         std::cout << name << std::endl;


### PR DESCRIPTION
The reference test application has been extended to include boolean and
void, the test was missing this
