### PR TITLE
fix: timestamp mismatch ZMQ/RPC for inputs

### DIFF
--- a/include/DoocsProcessScalar.h
+++ b/include/DoocsProcessScalar.h
@@ -80,7 +80,8 @@ namespace ChimeraTK {
     // let the DOOCS_T set function do all the dirty work and use the
     // get_value function afterwards to get the already assigned value
     _processScalar->accessData(0) = this->value();
-    _processScalar->write();
+    auto timestamp = DOOCS_T::get_timestamp().to_time_point();
+    _processScalar->write(VersionNumber(timestamp));
 
     updateOthers(true);
 

--- a/include/PropertyBase.h
+++ b/include/PropertyBase.h
@@ -119,7 +119,8 @@ namespace ChimeraTK {
         processVector[i] = dfct->value(i);
       }
     }
-    processArray->write();
+    auto timestamp = dfct->get_timestamp().to_time_point();
+    processArray->write(VersionNumber(timestamp));
 
     // Correct property length in case of a mismatch.
     if(doocsLen != processVector.size()) {

--- a/src/DoocsIfff.cc
+++ b/src/DoocsIfff.cc
@@ -141,7 +141,8 @@ namespace ChimeraTK {
     _f3Value->accessData(0) = ifff->f3_data;
 
     // write all with the same version number
-    VersionNumber v = {};
+    auto timestamp = DoocsIfff::get_timestamp().to_time_point();
+    VersionNumber v(timestamp);
     _i1Value->write(v);
     _f1Value->write(v);
     _f2Value->write(v);


### PR DESCRIPTION
This caused ZMQ connections to be interrupted due to the DOOCS-internal watchdog checking the connection after the ZMQ timeout with an RPC request.

Tested manually at A0