### PR TITLE
fix: set_error with not explicitly mapped source

### DIFF
--- a/src/VariableMapper.cc
+++ b/src/VariableMapper.cc
@@ -433,6 +433,10 @@ namespace ChimeraTK {
     errInfo.statusCodeSource = s;
     // matching status message source is found automatically by naming convention - if it exists
     errInfo.statusStringSource = s + "_message";
+    _usedInputVariables.insert(s);
+    if(_inputVariables.find(errInfo.statusStringSource) != _inputVariables.end()) {
+      _usedInputVariables.insert(errInfo.statusStringSource);
+    }
     _errorReportingInfos.push_back(errInfo);
   }
 


### PR DESCRIPTION
Fix set_error feature in case statusCodeSource is not explicitly mapped as DOOCS property.

See bug #11853.
There is no regression test here since the bug does not show up with ReferenceTestApplication. The latter does not optimize the variable network, but the bug depends on the optimization.