### PR TITLE
test: statusCodeSource of set_error

### DIFF
--- a/tests/serverTestSetError-DoocsVariableConfig.xml
+++ b/tests/serverTestSetError-DoocsVariableConfig.xml
@@ -2,8 +2,7 @@
 <device_server xmlns="https://github.com/ChimeraTK/ControlSystemAdapter-DoocsAdapter">
     <location name="INT">
         <set_error statusCodeSource="/INT/FROM_DEVICE_SCALAR" />
-        <D_spectrum name="TEST" source="/FLOAT/FROM_DEVICE_ARRAY" />
+	<property name="TO_DEVICE_SCALAR" source="/INT/TO_DEVICE_SCALAR" />
     </location>
 
-    <import>/</import>
 </device_server>

--- a/tests/src/serverTestSetError.cpp
+++ b/tests/src/serverTestSetError.cpp
@@ -48,3 +48,14 @@ BOOST_AUTO_TEST_CASE(testErrorNoMessageSource) {
   // there must be a generic error message
   TEST_WITH_TIMEOUT((check(), (lastErrString != "ok")));
 }
+
+BOOST_AUTO_TEST_CASE(setErrorSourceMarkedAsUsed) {
+  // kind of a regression test for bug #11853
+  // (set_error source was thrown away in optimization step since it was not marked as used)
+  // - do not explicitly map statusCodeSource of set_error
+  // - check that statusCodeSource goes into set of used variables
+  bool setErrorSourceMarkedAsUsed =
+      GlobalFixture::referenceTestApplication._unmappedVariables.find("/INT/FROM_DEVICE_SCALAR") ==
+      GlobalFixture::referenceTestApplication._unmappedVariables.end();
+  BOOST_TEST(setErrorSourceMarkedAsUsed);
+}


### PR DESCRIPTION
check that even when statusCodeSource for set_error is not explicitly mapped to DOOCS, it is kept as 'used variable'
This is a regression test for bug #11853.

Agreed in discussion with Martin H. that this makes more sense than refactoring of ReferenceTestApplication (which one could do in order to match more closely ApplicationCore Application)