### PR TITLE
Drothe/extended data matching

### DIFF
--- a/include/DoocsIfff.h
+++ b/include/DoocsIfff.h
@@ -19,12 +19,14 @@ namespace ChimeraTK {
     /// Constructor with history enabled
     DoocsIfff(EqFct* eqFct, std::string const& doocsPropertyName, boost::shared_ptr<NDRegisterAccessor<int>> i1Value,
         boost::shared_ptr<NDRegisterAccessor<float>> f1Value, boost::shared_ptr<NDRegisterAccessor<float>> f2Value,
-        boost::shared_ptr<NDRegisterAccessor<float>> f3Value, DoocsUpdater& updater);
+        boost::shared_ptr<NDRegisterAccessor<float>> f3Value, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     /// Constructor without history
     DoocsIfff(std::string const& doocsPropertyName, EqFct* eqFct, boost::shared_ptr<NDRegisterAccessor<int>> i1Value,
         boost::shared_ptr<NDRegisterAccessor<float>> f1Value, boost::shared_ptr<NDRegisterAccessor<float>> f2Value,
-        boost::shared_ptr<NDRegisterAccessor<float>> f3Value, DoocsUpdater& updater);
+        boost::shared_ptr<NDRegisterAccessor<float>> f3Value, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     void set(EqAdr* eqAdr, doocs::EqData* data1, doocs::EqData* data2, EqFct* eqFct) override;
     void auto_init() override;

--- a/include/DoocsIiii.h
+++ b/include/DoocsIiii.h
@@ -18,11 +18,13 @@ namespace ChimeraTK {
    public:
     /// Constructor with history enabled
     DoocsIiii(EqFct* eqFct, std::string const& doocsPropertyName,
-        boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater);
+        boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     /// Constructor without history
     DoocsIiii(std::string const& doocsPropertyName, EqFct* eqFct,
-        boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater);
+        boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     void set(EqAdr* eqAdr, doocs::EqData* data1, doocs::EqData* data2, EqFct* eqFct) override;
     void auto_init() override;

--- a/include/DoocsImage.h
+++ b/include/DoocsImage.h
@@ -36,7 +36,8 @@ namespace ChimeraTK {
   class DoocsImage : public D_imagec, public PropertyBase {
    public:
     DoocsImage(EqFct* eqFct, std::string const& doocsPropertyName,
-        boost::shared_ptr<ChimeraTK::NDRegisterAccessor<uint8_t>> const& processArray, DoocsUpdater& updater);
+        boost::shared_ptr<ChimeraTK::NDRegisterAccessor<uint8_t>> const& processArray, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     IMH imh{};
     IMH* getIMH() { return &imh; }

--- a/include/DoocsProcessArray.h
+++ b/include/DoocsProcessArray.h
@@ -21,7 +21,8 @@ namespace ChimeraTK {
     using THE_DOOCS_TYPE = typename std::result_of<decltype (&DOOCS_T::value)(DOOCS_T, int)>::type;
 
     DoocsProcessArray(EqFct* eqFct, std::string const& doocsPropertyName,
-        boost::shared_ptr<ChimeraTK::NDRegisterAccessor<DOOCS_PRIMITIVE_T>> const& processArray, DoocsUpdater& updater);
+        boost::shared_ptr<ChimeraTK::NDRegisterAccessor<DOOCS_PRIMITIVE_T>> const& processArray, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     /**
      * Overload the set function which is called by DOOCS to inject sending to the
@@ -54,9 +55,10 @@ namespace ChimeraTK {
 
   template<typename DOOCS_T, typename DOOCS_PRIMITIVE_T>
   DoocsProcessArray<DOOCS_T, DOOCS_PRIMITIVE_T>::DoocsProcessArray(EqFct* eqFct, const std::string& doocsPropertyName,
-      const boost::shared_ptr<ChimeraTK::NDRegisterAccessor<DOOCS_PRIMITIVE_T>>& processArray, DoocsUpdater& updater)
-  : DOOCS_T(doocsPropertyName, processArray->getNumberOfSamples(), eqFct), PropertyBase(doocsPropertyName, updater),
-    _processArray(processArray) {
+      const boost::shared_ptr<ChimeraTK::NDRegisterAccessor<DOOCS_PRIMITIVE_T>>& processArray, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : DOOCS_T(doocsPropertyName, processArray->getNumberOfSamples(), eqFct),
+    PropertyBase(doocsPropertyName, updater, matchingMode), _processArray(processArray) {
     // Check if the array length exceeds the maximum allowed length by DOOCS.
     // DOOCS does not report this as an error and instead silently truncates the
     // array length.
@@ -69,7 +71,7 @@ namespace ChimeraTK {
         << ". Try selecting a different DOOCS type in the mappng XML file, e.g. a D_spectrum!";
       throw ChimeraTK::logic_error(s.str());
     }
-    setupOutputVar(processArray);
+    setupOutputVar(_processArray);
   }
 
   template<typename DOOCS_T, typename DOOCS_PRIMITIVE_T>

--- a/include/DoocsProcessScalar.h
+++ b/include/DoocsProcessScalar.h
@@ -25,10 +25,12 @@ namespace ChimeraTK {
    public:
     /// constructor with history: EqFtc first
     DoocsProcessScalar(EqFct* eqFct, std::string doocsPropertyName,
-        boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater);
+        boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
     /// constructor without history: name first
     DoocsProcessScalar(std::string doocsPropertyName, EqFct* eqFct,
-        boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater);
+        boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
     /**
      * Override the Doocs set method which is triggered by the RPC calls.
@@ -51,16 +53,20 @@ namespace ChimeraTK {
 
   template<typename T, typename DOOCS_T>
   DoocsProcessScalar<T, DOOCS_T>::DoocsProcessScalar(EqFct* eqFct, std::string doocsPropertyName,
-      boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater)
-  : DOOCS_T(eqFct, doocsPropertyName), PropertyBase(doocsPropertyName, updater), _processScalar(processScalar) {
-    setupOutputVar(processScalar);
+      boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : DOOCS_T(eqFct, doocsPropertyName), PropertyBase(doocsPropertyName, updater, matchingMode),
+    _processScalar(processScalar) {
+    setupOutputVar(_processScalar);
   }
 
   template<typename T, typename DOOCS_T>
   DoocsProcessScalar<T, DOOCS_T>::DoocsProcessScalar(std::string doocsPropertyName, EqFct* eqFct,
-      boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater)
-  : DOOCS_T(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater), _processScalar(processScalar) {
-    setupOutputVar(processScalar);
+      boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<T>> const& processScalar, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : DOOCS_T(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater, matchingMode),
+    _processScalar(processScalar) {
+    setupOutputVar(_processScalar);
   }
 
   template<typename T, typename DOOCS_T>

--- a/include/DoocsSpectrum.h
+++ b/include/DoocsSpectrum.h
@@ -32,6 +32,7 @@ namespace ChimeraTK {
      */
     DoocsSpectrum(EqFct* eqFct, std::string const& doocsPropertyName,
         boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> const& processArray, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode,
         boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> startAccessor,
         boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> incrementAccessor);
 
@@ -48,6 +49,7 @@ namespace ChimeraTK {
      */
     DoocsSpectrum(EqFct* eqFct, std::string const& doocsPropertyName,
         boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> const& processArray, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode,
         boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> startAccessor,
         boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> incrementAccessor, size_t numberOfBuffers);
 

--- a/include/DoocsXY.h
+++ b/include/DoocsXY.h
@@ -18,7 +18,8 @@ namespace ChimeraTK {
    public:
     DoocsXy(EqFct* eqFct, std::string const& doocsPropertyName,
         boost::shared_ptr<NDRegisterAccessor<float>> const& xValues,
-        boost::shared_ptr<NDRegisterAccessor<float>> const& yValues, DoocsUpdater& updater);
+        boost::shared_ptr<NDRegisterAccessor<float>> const& yValues, DoocsUpdater& updater,
+        DataConsistencyGroup::MatchingMode matchingMode);
 
    protected:
     void updateDoocsBuffer(const TransferElementID& elementId) override;

--- a/src/DoocsIfff.cc
+++ b/src/DoocsIfff.cc
@@ -18,9 +18,10 @@ namespace ChimeraTK {
   DoocsIfff::DoocsIfff(EqFct* eqFct, std::string const& doocsPropertyName,
       boost::shared_ptr<NDRegisterAccessor<int>> i1Value, boost::shared_ptr<NDRegisterAccessor<float>> f1Value,
       boost::shared_ptr<NDRegisterAccessor<float>> f2Value, boost::shared_ptr<NDRegisterAccessor<float>> f3Value,
-      DoocsUpdater& updater)
-  : D_ifff(eqFct, doocsPropertyName), PropertyBase(doocsPropertyName, updater), _i1Value(std::move(i1Value)),
-    _f1Value(std::move(f1Value)), _f2Value(std::move(f2Value)), _f3Value(std::move(f3Value)) {
+      DoocsUpdater& updater, DataConsistencyGroup::MatchingMode matchingMode)
+  : D_ifff(eqFct, doocsPropertyName), PropertyBase(doocsPropertyName, updater, matchingMode),
+    _i1Value(std::move(i1Value)), _f1Value(std::move(f1Value)), _f2Value(std::move(f2Value)),
+    _f3Value(std::move(f3Value)) {
     checkSourceConsistency();
     registerIfffSources();
   }
@@ -29,9 +30,10 @@ namespace ChimeraTK {
   DoocsIfff::DoocsIfff(std::string const& doocsPropertyName, EqFct* eqFct,
       boost::shared_ptr<NDRegisterAccessor<int>> i1Value, boost::shared_ptr<NDRegisterAccessor<float>> f1Value,
       boost::shared_ptr<NDRegisterAccessor<float>> f2Value, boost::shared_ptr<NDRegisterAccessor<float>> f3Value,
-      DoocsUpdater& updater)
-  : D_ifff(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater), _i1Value(std::move(i1Value)),
-    _f1Value(std::move(f1Value)), _f2Value(std::move(f2Value)), _f3Value(std::move(f3Value)) {
+      DoocsUpdater& updater, DataConsistencyGroup::MatchingMode matchingMode)
+  : D_ifff(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater, matchingMode),
+    _i1Value(std::move(i1Value)), _f1Value(std::move(f1Value)), _f2Value(std::move(f2Value)),
+    _f3Value(std::move(f3Value)) {
     checkSourceConsistency();
     registerIfffSources();
   }
@@ -52,10 +54,10 @@ namespace ChimeraTK {
   }
 
   void DoocsIfff::registerIfffSources() {
-    registerVariable(OneDRegisterAccessor<int>(_i1Value));
-    registerVariable(OneDRegisterAccessor<float>(_f1Value));
-    registerVariable(OneDRegisterAccessor<float>(_f2Value));
-    registerVariable(OneDRegisterAccessor<float>(_f3Value));
+    registerVariable(_i1Value);
+    registerVariable(_f1Value);
+    registerVariable(_f2Value);
+    registerVariable(_f3Value);
     _outputVarForVersionNum = _i1Value;
   }
 

--- a/src/DoocsIiii.cc
+++ b/src/DoocsIiii.cc
@@ -15,15 +15,17 @@
 
 namespace ChimeraTK {
   DoocsIiii::DoocsIiii(EqFct* eqFct, std::string const& doocsPropertyName,
-      boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater)
-  : D_iiii(eqFct, doocsPropertyName), PropertyBase(doocsPropertyName, updater), _iiiiValue(iiiiValue) {
+      boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : D_iiii(eqFct, doocsPropertyName), PropertyBase(doocsPropertyName, updater, matchingMode), _iiiiValue(iiiiValue) {
     registerIiiiSources();
   }
 
   // Constructor without history
   DoocsIiii::DoocsIiii(std::string const& doocsPropertyName, EqFct* eqFct,
-      boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater)
-  : D_iiii(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater), _iiiiValue(iiiiValue) {
+      boost::shared_ptr<NDRegisterAccessor<int>> const& iiiiValue, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : D_iiii(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater, matchingMode), _iiiiValue(iiiiValue) {
     registerIiiiSources();
   }
 
@@ -36,7 +38,7 @@ namespace ChimeraTK {
     if(_iiiiValue->isReadOnly()) {
       this->set_ro_access();
     }
-    registerVariable(OneDRegisterAccessor<int>(_iiiiValue));
+    registerVariable(_iiiiValue);
     _outputVarForVersionNum = _iiiiValue;
   }
 

--- a/src/DoocsImage.cc
+++ b/src/DoocsImage.cc
@@ -65,14 +65,16 @@ namespace ChimeraTK {
   /************************* DoocsImage ************************************************************************/
 
   DoocsImage::DoocsImage(EqFct* eqFct, std::string const& doocsPropertyName,
-      boost::shared_ptr<ChimeraTK::NDRegisterAccessor<uint8_t>> const& processArray, DoocsUpdater& updater)
-  : D_imagec(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater), _processArray(processArray) {
+      boost::shared_ptr<ChimeraTK::NDRegisterAccessor<uint8_t>> const& processArray, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : D_imagec(doocsPropertyName, eqFct), PropertyBase(doocsPropertyName, updater, matchingMode),
+    _processArray(processArray) {
     if(_processArray->isWriteable()) {
       // It could only be writable if the application implements it as an output with back-channel.
       // Then consider this application to have a logical bug.
       throw logic_error("writable images not supported by DoocsImage");
     }
-    setupOutputVar(processArray);
+    setupOutputVar(_processArray);
   }
 
   void DoocsImage::updateDoocsBuffer(const TransferElementID& transferElementId) {

--- a/src/DoocsPVFactory.cc
+++ b/src/DoocsPVFactory.cc
@@ -55,19 +55,19 @@ namespace ChimeraTK {
     // "._HIST", which also has to fit into the 64 characters
     if(propertyDescription.name.length() > 64 - 6) {
       std::cerr << "WARNING: Disabling history for " << processArray->getName() << ". Name is too long." << std::endl;
-      doocsPV.reset(
-          new DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>(propertyDescription.name, _eqFct, processArray, _updater));
+      doocsPV = boost::make_shared<DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>>(
+          propertyDescription.name, _eqFct, processArray, _updater, propertyDescription.dataMatching);
     }
     else {
       if(propertyDescription.hasHistory) {
         // version with history: EqFtc first
-        doocsPV.reset(new DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>(
-            _eqFct, propertyDescription.name, processArray, _updater));
+        doocsPV = boost::make_shared<DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>>(
+            _eqFct, propertyDescription.name, processArray, _updater, propertyDescription.dataMatching);
       }
       else {
         // version without history: name first
-        doocsPV.reset(new DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>(
-            propertyDescription.name, _eqFct, processArray, _updater));
+        doocsPV = boost::make_shared<DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>>(
+            propertyDescription.name, _eqFct, processArray, _updater, propertyDescription.dataMatching);
       }
     } // if name too long
 
@@ -80,10 +80,6 @@ namespace ChimeraTK {
     if(propertyDescription.publishZMQ) {
       boost::dynamic_pointer_cast<DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>>(doocsPV)->publishZeroMQ();
     }
-
-    // set data matching mode (need to call before setMacroPulseNumberSource, as the mode is checked there)
-    boost::dynamic_pointer_cast<DoocsProcessScalar<DOOCS_PRIMITIVE_T, DOOCS_T>>(doocsPV)->setMatchingMode(
-        propertyDescription.dataMatching);
 
     // set macro pulse number source, if configured
     if(!propertyDescription.macroPulseNumberSource.empty()) {
@@ -123,8 +119,8 @@ namespace ChimeraTK {
 
     assert(processArray->getNumberOfChannels() == 1);
     assert(processArray->getNumberOfSamples() == 1); // array of strings is not supported
-    boost::shared_ptr<DoocsProcessScalar<std::string, DTextUnifier>> doocsPV(
-        new DoocsProcessScalar<std::string, DTextUnifier>(_eqFct, propertyDescription.name, processArray, _updater));
+    auto doocsPV = boost::make_shared<DoocsProcessScalar<std::string, DTextUnifier>>(
+        _eqFct, propertyDescription.name, processArray, _updater, propertyDescription.dataMatching);
 
     // set read only mode if configures in the xml file or for output variables
     if(!processArray->isWriteable() || !propertyDescription.isWriteable) {
@@ -135,9 +131,6 @@ namespace ChimeraTK {
     if(propertyDescription.publishZMQ) {
       doocsPV->publishZeroMQ();
     }
-
-    // set data matching mode (need to call before setMacroPulseNumberSource, as the mode is checked there)
-    doocsPV->setMatchingMode(propertyDescription.dataMatching);
 
     // set macro pulse number source, if configured
     if(!propertyDescription.macroPulseNumberSource.empty()) {
@@ -186,14 +179,14 @@ namespace ChimeraTK {
     //    assert(processArray->getNumberOfChannels() == 1);
     boost::shared_ptr<DoocsSpectrum> doocsPV;
     if(spectrumDescription.numberOfBuffers == 1) {
-      doocsPV.reset(new DoocsSpectrum(_eqFct, spectrumDescription.name,
-          getTypeChangingDecorator<float>(processVariable, DecoratorType::C_style_conversion), _updater, startAccessor,
-          incrementAccessor));
+      doocsPV = boost::make_shared<DoocsSpectrum>(_eqFct, spectrumDescription.name,
+          getTypeChangingDecorator<float>(processVariable, DecoratorType::C_style_conversion), _updater,
+          spectrumDescription.dataMatching, startAccessor, incrementAccessor);
     }
     else {
-      doocsPV.reset(new DoocsSpectrum(_eqFct, spectrumDescription.name,
-          getTypeChangingDecorator<float>(processVariable, DecoratorType::C_style_conversion), _updater, startAccessor,
-          incrementAccessor, spectrumDescription.numberOfBuffers));
+      doocsPV = boost::make_shared<DoocsSpectrum>(_eqFct, spectrumDescription.name,
+          getTypeChangingDecorator<float>(processVariable, DecoratorType::C_style_conversion), _updater,
+          spectrumDescription.dataMatching, startAccessor, incrementAccessor, spectrumDescription.numberOfBuffers);
     }
 
     // set read only mode if configures in the xml file or for output variables
@@ -226,9 +219,6 @@ namespace ChimeraTK {
       spectrum->egu(axis.logarithmic, axis.start, axis.stop, axis.label.c_str());
     }
 
-    // set data matching mode (need to call before setMacroPulseNumberSource, as the mode is checked there)
-    doocsPV->setMatchingMode(spectrumDescription.dataMatching);
-
     // set macro pulse number source, if configured
     if(!spectrumDescription.macroPulseNumberSource.empty()) {
       auto mpnSource = _controlSystemPVManager->getProcessVariable(spectrumDescription.macroPulseNumberSource);
@@ -250,7 +240,8 @@ namespace ChimeraTK {
   boost::shared_ptr<D_fct> DoocsPVFactory::createDoocsImage(ImageDescription const& imageDescription) {
     auto processVariable = _controlSystemPVManager->getProcessVariable(imageDescription.source);
     boost::shared_ptr<DoocsImage> doocsPV = boost::make_shared<DoocsImage>(_eqFct, imageDescription.name,
-        getTypeChangingDecorator<unsigned char>(processVariable, DecoratorType::C_style_conversion), _updater);
+        getTypeChangingDecorator<unsigned char>(processVariable, DecoratorType::C_style_conversion), _updater,
+        imageDescription.dataMatching);
 
     if(not imageDescription.description.empty()) {
       doocsPV->set_descr_value(imageDescription.description);
@@ -263,8 +254,6 @@ namespace ChimeraTK {
       doocsPV->publishZeroMQ();
     }
 
-    // set data matching mode (need to call before setMacroPulseNumberSource, as the mode is checked there)
-    doocsPV->setMatchingMode(imageDescription.dataMatching);
     // set macro pulse number source, if configured
     if(!imageDescription.macroPulseNumberSource.empty()) {
       auto mpnSource = _controlSystemPVManager->getProcessVariable(imageDescription.macroPulseNumberSource);
@@ -287,10 +276,10 @@ namespace ChimeraTK {
     auto xProcessVariable = _controlSystemPVManager->getProcessVariable(xyDescription.xSource);
     auto yProcessVariable = _controlSystemPVManager->getProcessVariable(xyDescription.ySource);
 
-    boost::shared_ptr<DoocsXy> doocsPV;
-    doocsPV.reset(new DoocsXy(_eqFct, xyDescription.name,
+    auto doocsPV = boost::make_shared<DoocsXy>(_eqFct, xyDescription.name,
         getTypeChangingDecorator<float>(xProcessVariable, DecoratorType::C_style_conversion),
-        getTypeChangingDecorator<float>(yProcessVariable, DecoratorType::C_style_conversion), _updater));
+        getTypeChangingDecorator<float>(yProcessVariable, DecoratorType::C_style_conversion), _updater,
+        xyDescription.dataMatching);
 
     auto xy = boost::static_pointer_cast<DoocsXy>(doocsPV);
 
@@ -328,22 +317,21 @@ namespace ChimeraTK {
     boost::shared_ptr<DoocsIfff> doocsPV;
 
     if(ifffDescription.hasHistory) {
-      doocsPV.reset(new DoocsIfff(_eqFct, ifffDescription.name,
+      doocsPV = boost::make_shared<DoocsIfff>(_eqFct, ifffDescription.name,
           getTypeChangingDecorator<int>(i1ProcessVariable, DecoratorType::C_style_conversion),
           getTypeChangingDecorator<float>(f1ProcessVariable, DecoratorType::C_style_conversion),
           getTypeChangingDecorator<float>(f2ProcessVariable, DecoratorType::C_style_conversion),
-          getTypeChangingDecorator<float>(f3ProcessVariable, DecoratorType::C_style_conversion), _updater));
+          getTypeChangingDecorator<float>(f3ProcessVariable, DecoratorType::C_style_conversion), _updater,
+          ifffDescription.dataMatching);
     }
     else {
-      doocsPV.reset(new DoocsIfff(ifffDescription.name, _eqFct,
+      doocsPV = boost::make_shared<DoocsIfff>(ifffDescription.name, _eqFct,
           getTypeChangingDecorator<int>(i1ProcessVariable, DecoratorType::C_style_conversion),
           getTypeChangingDecorator<float>(f1ProcessVariable, DecoratorType::C_style_conversion),
           getTypeChangingDecorator<float>(f2ProcessVariable, DecoratorType::C_style_conversion),
-          getTypeChangingDecorator<float>(f3ProcessVariable, DecoratorType::C_style_conversion), _updater));
+          getTypeChangingDecorator<float>(f3ProcessVariable, DecoratorType::C_style_conversion), _updater,
+          ifffDescription.dataMatching);
     }
-
-    // set specified data_matching mode
-    doocsPV->setMatchingMode(ifffDescription.dataMatching);
 
     // set macro pulse number source, if configured
     if(!ifffDescription.macroPulseNumberSource.empty()) {
@@ -376,16 +364,15 @@ namespace ChimeraTK {
 
     boost::shared_ptr<DoocsIiii> doocsPV;
     if(iiiiDescription.hasHistory) {
-      doocsPV.reset(new DoocsIiii(_eqFct, iiiiDescription.name,
-          getTypeChangingDecorator<int>(iiiiProcessVariable, DecoratorType::C_style_conversion), _updater));
+      doocsPV = boost::make_shared<DoocsIiii>(_eqFct, iiiiDescription.name,
+          getTypeChangingDecorator<int>(iiiiProcessVariable, DecoratorType::C_style_conversion), _updater,
+          iiiiDescription.dataMatching);
     }
     else {
-      doocsPV.reset(new DoocsIiii(iiiiDescription.name, _eqFct,
-          getTypeChangingDecorator<int>(iiiiProcessVariable, DecoratorType::C_style_conversion), _updater));
+      doocsPV = boost::make_shared<DoocsIiii>(iiiiDescription.name, _eqFct,
+          getTypeChangingDecorator<int>(iiiiProcessVariable, DecoratorType::C_style_conversion), _updater,
+          iiiiDescription.dataMatching);
     }
-
-    // set specified data_matching mode
-    doocsPV->setMatchingMode(iiiiDescription.dataMatching);
 
     // set macro pulse number source, if configured
     if(iiiiDescription.macroPulseNumberSource.size() > 0) {
@@ -510,8 +497,8 @@ namespace ChimeraTK {
 
     ///@todo FIXME Add the decorator type as option  to the array description, and
     /// only use C_style_conversion as default
-    boost::shared_ptr<PropertyBase> doocsPV(
-        new DoocsProcessArray<DOOCS_T, DOOCS_PRIMITIVE_T>(_eqFct, propertyDescription.name, processArray, _updater));
+    auto doocsPV = boost::make_shared<DoocsProcessArray<DOOCS_T, DOOCS_PRIMITIVE_T>>(
+        _eqFct, propertyDescription.name, processArray, _updater, propertyDescription.dataMatching);
 
     // set read only mode if configures in the xml file or for output variables
     if(!processVariable->isWriteable() || !propertyDescription.isWriteable) {
@@ -522,9 +509,6 @@ namespace ChimeraTK {
     if(propertyDescription.publishZMQ) {
       doocsPV->publishZeroMQ();
     }
-
-    // set data matching mode (need to call before setMacroPulseNumberSource, as the mode is checked there)
-    doocsPV->setMatchingMode(propertyDescription.dataMatching);
 
     // set macro pulse number source, if configured
     if(!propertyDescription.macroPulseNumberSource.empty()) {

--- a/src/DoocsSpectrum.cc
+++ b/src/DoocsSpectrum.cc
@@ -16,28 +16,31 @@ namespace ChimeraTK {
 
   DoocsSpectrum::DoocsSpectrum(EqFct* eqFct, std::string const& doocsPropertyName,
       boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> const& processArray, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode,
       boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> startAccessor,
       boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> incrementAccessor)
   : D_spectrum(doocsPropertyName, processArray->getNumberOfSamples(), eqFct, processArray->isWriteable()),
-    PropertyBase(doocsPropertyName, updater), _processArray(processArray), _startAccessor(std::move(startAccessor)),
-    _incrementAccessor(std::move(incrementAccessor)), _nBuffers(1) {
-    setupOutputVar(processArray);
+    PropertyBase(doocsPropertyName, updater, matchingMode), _processArray(processArray),
+    _startAccessor(std::move(startAccessor)), _incrementAccessor(std::move(incrementAccessor)), _nBuffers(1) {
+    setupOutputVar(_processArray);
 
     addParameterAccessors();
   }
 
   DoocsSpectrum::DoocsSpectrum(EqFct* eqFct, std::string const& doocsPropertyName,
       boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> const& processArray, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode,
       boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> startAccessor,
       boost::shared_ptr<ChimeraTK::NDRegisterAccessor<float>> incrementAccessor, size_t numberOfBuffers)
   : D_spectrum(doocsPropertyName, processArray->getNumberOfSamples(), eqFct, numberOfBuffers, DATA_A_FLOAT),
-    PropertyBase(doocsPropertyName, updater), _processArray(processArray), _startAccessor(std::move(startAccessor)),
-    _incrementAccessor(std::move(incrementAccessor)), _nBuffers(numberOfBuffers) {
+    PropertyBase(doocsPropertyName, updater, matchingMode), _processArray(processArray),
+    _startAccessor(std::move(startAccessor)), _incrementAccessor(std::move(incrementAccessor)),
+    _nBuffers(numberOfBuffers) {
     if(_nBuffers > 1 && !processArray->isReadable()) {
       throw ChimeraTK::logic_error(
           "D_spectrum '" + _processArray->getName() + "' has numberOfBuffers > 1 but is not readable.");
     }
-    setupOutputVar(processArray);
+    setupOutputVar(_processArray);
 
     addParameterAccessors();
   }

--- a/src/DoocsXy.cc
+++ b/src/DoocsXy.cc
@@ -10,11 +10,12 @@
 namespace ChimeraTK {
   DoocsXy::DoocsXy(EqFct* eqFct, std::string const& doocsPropertyName,
       boost::shared_ptr<NDRegisterAccessor<float>> const& xValues,
-      boost::shared_ptr<NDRegisterAccessor<float>> const& yValues, DoocsUpdater& updater)
-  : D_xy(doocsPropertyName, xValues->getNumberOfSamples(), eqFct), PropertyBase(doocsPropertyName, updater),
-    _xValues(xValues), _yValues(yValues) {
-    setupOutputVar(xValues);
-    setupOutputVar(yValues);
+      boost::shared_ptr<NDRegisterAccessor<float>> const& yValues, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : D_xy(doocsPropertyName, xValues->getNumberOfSamples(), eqFct),
+    PropertyBase(doocsPropertyName, updater, matchingMode), _xValues(xValues), _yValues(yValues) {
+    setupOutputVar(_xValues);
+    setupOutputVar(_yValues);
   }
 
   void DoocsXy::updateDoocsBuffer(const TransferElementID& elementId) {

--- a/src/PropertyBase.cc
+++ b/src/PropertyBase.cc
@@ -8,11 +8,11 @@
 
 namespace ChimeraTK {
 
-  void PropertyBase::registerVariable(const TransferElementAbstractor& var) {
+  void PropertyBase::registerVariable(TransferElementAbstractor& var) {
     if(var.isReadable()) {
       auto id = var.getId();
-      _doocsUpdater.addVariable(var, getEqFct(), [this, id] { return updateDoocsBuffer(id); });
       _consistencyGroup.add(var);
+      _doocsUpdater.addVariable(var, getEqFct(), [this, id] { return updateDoocsBuffer(id); });
     }
   }
 
@@ -131,10 +131,7 @@ namespace ChimeraTK {
       const boost::shared_ptr<ChimeraTK::NDRegisterAccessor<int64_t>>& macroPulseNumberSource) {
     _macroPulseNumberSource = macroPulseNumberSource;
     if(_consistencyGroup.getMatchingMode() != DataConsistencyGroup::MatchingMode::none) {
-      _consistencyGroup.add(macroPulseNumberSource);
-      auto id = macroPulseNumberSource->getId();
-      _doocsUpdater.addVariable(ChimeraTK::ScalarRegisterAccessor<int64_t>(macroPulseNumberSource), getEqFct(),
-          [this, id] { return updateDoocsBuffer(id); });
+      registerVariable(_macroPulseNumberSource);
     }
     else {
       // We don't need to match up anything with it when it changes, but we have to register this at least once

--- a/src/VariableMapper.cc
+++ b/src/VariableMapper.cc
@@ -733,6 +733,9 @@ namespace ChimeraTK {
     else if(txt == "none") {
       dataMatching = DataConsistencyGroup::MatchingMode::none;
     }
+    else if(txt == "historized") {
+      dataMatching = DataConsistencyGroup::MatchingMode::historized;
+    }
     else {
       throw std::invalid_argument("Unknown data matching mode specified in xml file: " + txt);
     }

--- a/tests/serverTestDataMatching-DoocsVariableConfig.xml
+++ b/tests/serverTestDataMatching-DoocsVariableConfig.xml
@@ -8,11 +8,11 @@
 
   <location name="UINT">
     <data_matching>exact</data_matching>
-    <property source="/UINT/FROM_DEVICE_SCALAR" name="FROM_DEVICE_SCALAR">
-    </property>
-    <property source="/UINT/FROM_DEVICE_ARRAY" name="FROM_DEVICE_ARRAY">
-    </property>
     <import>/UINT</import>
+  </location>
+  <location name="DOUBLE">
+    <data_matching>historized</data_matching>
+    <import>/DOUBLE</import>
   </location>
 
 

--- a/tests/src/serverTestDataMatching.cpp
+++ b/tests/src/serverTestDataMatching.cpp
@@ -43,6 +43,7 @@ BOOST_AUTO_TEST_CASE(testProcessScalar) {
   float expectedFloat = 42.42F;
   DoocsServerTestHelper::doocsSet<unsigned int>("//UINT/TO_DEVICE_SCALAR", expectedUnsignedInt);
   DoocsServerTestHelper::doocsSet<float>("//UNMAPPED/FLOAT.TO_DEVICE_SCALAR", expectedFloat);
+  DoocsServerTestHelper::doocsSet<double>("//DOUBLE/TO_DEVICE_SCALAR", expectedFloat);
 
   GlobalFixture::referenceTestApplication.runMainLoopOnce();
 
@@ -50,6 +51,7 @@ BOOST_AUTO_TEST_CASE(testProcessScalar) {
       DoocsServerTestHelper::doocsGet<unsigned int>("//UINT/FROM_DEVICE_SCALAR") - expectedUnsignedInt < 1e-6);
   CHECK_WITH_TIMEOUT(
       DoocsServerTestHelper::doocsGet<float>("//UNMAPPED/FLOAT.FROM_DEVICE_SCALAR") - expectedFloat < 1e-6);
+  CHECK_WITH_TIMEOUT(DoocsServerTestHelper::doocsGet<double>("//DOUBLE/FROM_DEVICE_SCALAR") - expectedFloat < 1e-6);
 
   // Send MPN and values with different version numbers
   GlobalFixture::referenceTestApplication.versionNumber = ChimeraTK::VersionNumber();
@@ -57,10 +59,12 @@ BOOST_AUTO_TEST_CASE(testProcessScalar) {
 
   GlobalFixture::referenceTestApplication.versionNumber = ChimeraTK::VersionNumber();
   auto lastExpectedUnsignedInt = expectedUnsignedInt;
+  auto lastExpectedDouble = expectedFloat;
   expectedUnsignedInt = 2U;
   expectedFloat = 2.42F;
   DoocsServerTestHelper::doocsSet<unsigned int>("//UINT/TO_DEVICE_SCALAR", expectedUnsignedInt);
   DoocsServerTestHelper::doocsSet<float>("//UNMAPPED/FLOAT.TO_DEVICE_SCALAR", expectedFloat);
+  DoocsServerTestHelper::doocsSet<double>("//DOUBLE/TO_DEVICE_SCALAR", expectedFloat);
 
   GlobalFixture::referenceTestApplication.runMainLoopOnce();
 
@@ -69,6 +73,8 @@ BOOST_AUTO_TEST_CASE(testProcessScalar) {
   usleep(1000000);
   BOOST_CHECK_EQUAL(
       DoocsServerTestHelper::doocsGet<unsigned int>("//UINT/FROM_DEVICE_SCALAR"), lastExpectedUnsignedInt);
+  // double value must also not be updated because data matching = historized
+  BOOST_CHECK_EQUAL(DoocsServerTestHelper::doocsGet<double>("//DOUBLE/FROM_DEVICE_SCALAR"), lastExpectedDouble);
 
   // Float value has to get the update even with version number mismatch
   // because data matching is none

--- a/tests/src/serverTestZeroMQ.cpp
+++ b/tests/src/serverTestZeroMQ.cpp
@@ -204,7 +204,7 @@ struct ZMQFixture {
       CHECK_WITH_TIMEOUT(dataReceived > 0);
       usleep(10000);
       BOOST_CHECK_EQUAL(dataReceived, 1);
-      dataReceived--;
+      dataReceived = 0;
       {
         std::lock_guard<std::mutex> lock(mutex);
         BOOST_CHECK_EQUAL(received.error() != 0, isError);

--- a/tests/src/testDoocsImage.cc
+++ b/tests/src/testDoocsImage.cc
@@ -91,7 +91,7 @@ BOOST_FIXTURE_TEST_CASE(fromDeviceTest, DeviceFixture) {
   DoocsUpdater updater;
 
   // EqFct = NULL, not required for our purpose
-  DoocsImage doocsImage(nullptr, "someName", controlSystemVariable, updater);
+  DoocsImage doocsImage(nullptr, "someName", controlSystemVariable, updater, DataConsistencyGroup::MatchingMode::exact);
 
   // generate an image and send it via the device side
   ChimeraTK::OneDRegisterAccessor acc(deviceVariable);

--- a/tests/src/testDoocsProcessScalar.cpp
+++ b/tests/src/testDoocsProcessScalar.cpp
@@ -47,7 +47,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(toDeviceIntegerTypeTest, T, integer_test_types) {
   controlSystemVariable->accessData(0) = 0;
 
   // just write to the doocs scalar, it is automatically sending
-  DoocsProcessScalar<T, D_int> doocsScalar(&myLocation, "TO_DEVICE_VARIABLE", controlSystemVariable, updater);
+  DoocsProcessScalar<T, D_int> doocsScalar(
+      &myLocation, "TO_DEVICE_VARIABLE", controlSystemVariable, updater, DataConsistencyGroup::MatchingMode::exact);
 
   BOOST_CHECK(setDoocsValue(doocsScalar, 42) == 0);
   BOOST_CHECK(controlSystemVariable->accessData(0) == 42);
@@ -88,7 +89,8 @@ BOOST_AUTO_TEST_CASE(toDeviceFloatTest) {
   controlSystemFloat->accessData(0) = 0;
 
   // just write to the doocs scalar, it is automatically sending
-  DoocsProcessScalar<float, D_float> doocsScalar(&myLocation, "TO_DEVICE_FLOAT", controlSystemFloat, updater);
+  DoocsProcessScalar<float, D_float> doocsScalar(
+      &myLocation, "TO_DEVICE_FLOAT", controlSystemFloat, updater, DataConsistencyGroup::MatchingMode::exact);
 
   BOOST_CHECK(setDoocsValue(doocsScalar, 12.125) == 0);
   BOOST_CHECK_CLOSE(controlSystemFloat->accessData(0), 12.125, 0.00001);
@@ -124,7 +126,8 @@ BOOST_AUTO_TEST_CASE(toDeviceDoubleTest) {
   controlSystemDouble->accessData(0) = 0;
 
   // just write to the doocs scalar, it is automatically sending
-  DoocsProcessScalar<double, D_double> doocsScalar(&myLocation, "TO_DEVICE_DOUBLE", controlSystemDouble, updater);
+  DoocsProcessScalar<double, D_double> doocsScalar(
+      &myLocation, "TO_DEVICE_DOUBLE", controlSystemDouble, updater, DataConsistencyGroup::MatchingMode::exact);
 
   BOOST_CHECK(setDoocsValue(doocsScalar, 12.125) == 0);
   BOOST_CHECK(controlSystemDouble->accessData(0) == 12.125);
@@ -161,7 +164,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fromDeviceIntegerTypeTest, T, integer_test_types) 
   controlSystemVariable->accessData(0) = 0;
 
   // initialise the doocs scalar
-  DoocsProcessScalar<T, D_int> doocsScalar(&myLocation, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater);
+  DoocsProcessScalar<T, D_int> doocsScalar(
+      &myLocation, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater, DataConsistencyGroup::MatchingMode::exact);
 
   deviceVariable->accessData(0) = 42;
   deviceVariable->write();
@@ -198,7 +202,7 @@ BOOST_AUTO_TEST_CASE(toDeviceStringTest) {
 
   // just write to the doocs scalar, it is automatically sending
   DoocsProcessScalar<std::string, DTextUnifier> doocsScalar(
-      &myLocation, "TO_DEVICE_STRING", controlSystemFloat, updater);
+      &myLocation, "TO_DEVICE_STRING", controlSystemFloat, updater, DataConsistencyGroup::MatchingMode::exact);
 
   BOOST_CHECK(setDoocsValue(doocsScalar, "twelvepointonetwofive") == 0);
   BOOST_CHECK(controlSystemFloat->accessData(0) == "twelvepointonetwofive");
@@ -236,7 +240,7 @@ BOOST_AUTO_TEST_CASE(fromDeviceStringTest) {
 
   // initialise the doocs scalar
   DoocsProcessScalar<std::string, DTextUnifier> doocsScalar(
-      nullptr, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater);
+      nullptr, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater, DataConsistencyGroup::MatchingMode::exact);
 
   deviceVariable->accessData(0) = "twelvepointonetwofive";
   deviceVariable->write();
@@ -265,7 +269,8 @@ BOOST_AUTO_TEST_CASE(fromDeviceFloatTest) {
   controlSystemVariable->accessData(0) = 0.0;
 
   // initialise the doocs scalar
-  DoocsProcessScalar<float, D_float> doocsScalar(&myLocation, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater);
+  DoocsProcessScalar<float, D_float> doocsScalar(
+      &myLocation, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater, DataConsistencyGroup::MatchingMode::exact);
 
   deviceVariable->accessData(0) = 12.125;
   deviceVariable->write();
@@ -294,7 +299,8 @@ BOOST_AUTO_TEST_CASE(fromDeviceDoubleTest) {
   controlSystemVariable->accessData(0) = 0;
 
   // initialise the doocs scalar
-  DoocsProcessScalar<double, D_double> doocsScalar(&myLocation, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater);
+  DoocsProcessScalar<double, D_double> doocsScalar(
+      &myLocation, "FROM_DEVICE_VARIABLE", controlSystemVariable, updater, DataConsistencyGroup::MatchingMode::exact);
 
   deviceVariable->accessData(0) = 12.125;
   deviceVariable->write();

--- a/tests/src/testDoocsSpectrum.cpp
+++ b/tests/src/testDoocsSpectrum.cpp
@@ -23,8 +23,9 @@ using namespace ChimeraTK;
 class TestableDoocsSpectrum : public DoocsSpectrum {
  public:
   TestableDoocsSpectrum(EqFct* const eqFct, std::string const& doocsPropertyName,
-      boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<float>> const& processArray, DoocsUpdater& updater)
-  : DoocsSpectrum(eqFct, doocsPropertyName, processArray, updater, nullptr, nullptr) {}
+      boost::shared_ptr<typename ChimeraTK::NDRegisterAccessor<float>> const& processArray, DoocsUpdater& updater,
+      DataConsistencyGroup::MatchingMode matchingMode)
+  : DoocsSpectrum(eqFct, doocsPropertyName, processArray, updater, matchingMode, nullptr, nullptr) {}
 
   using DoocsSpectrum::sendToDevice;
 };
@@ -52,8 +53,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(toDeviceTest, T, simple_test_types) {
   // Write to the doocs spectrum and send it.
   // We use the 'testable' version which exposes sendToDevice, which otherwise
   // is protected.
-  TestableDoocsSpectrum doocsSpectrum(
-      nullptr, "someName", getTypeChangingDecorator<float>(controlSystemVariable), updater);
+  TestableDoocsSpectrum doocsSpectrum(nullptr, "someName", getTypeChangingDecorator<float>(controlSystemVariable),
+      updater, DataConsistencyGroup::MatchingMode::exact);
 
   // create unique signature for each template parameter
   // negative factor for signed values
@@ -93,8 +94,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(fromDeviceTest, T, simple_test_types) {
   DoocsUpdater updater;
 
   // initialise the doocs spectrum
-  DoocsSpectrum doocsSpectrum(
-      nullptr, "someName", getTypeChangingDecorator<float>(controlSystemVariable), updater, nullptr, nullptr);
+  DoocsSpectrum doocsSpectrum(nullptr, "someName", getTypeChangingDecorator<float>(controlSystemVariable), updater,
+      DataConsistencyGroup::MatchingMode::exact, nullptr, nullptr);
   for(size_t i = 0; i < arraySize; ++i) {
     doocsSpectrum.fill_spectrum(i, 0);
   }


### PR DESCRIPTION
It should be possible to compile & run tests with 0, 1 or 2 of our commits:

no commits = tests that DeviceAccess is backwards compatible
first commit = get rid of deprecated code, but do not use new feature
second commit = test new feature MatchingMode::historized
